### PR TITLE
refactoring word types

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,4 +1,4 @@
-module Main exposing (main)
+module Main exposing (main, tileFontColor)
 
 import Array exposing (Array)
 import Browser
@@ -222,6 +222,7 @@ tileBorderColor tile =
                     colorBlack
 
 
+tileFontColor : Match -> Color
 tileFontColor match =
     case match of
         No ->

--- a/src/Word.elm
+++ b/src/Word.elm
@@ -1,0 +1,52 @@
+module Word exposing (..)
+
+
+type Match
+    = No --grey
+    | Exact --green
+    | Almost --yellow
+    | Unmatched --white
+
+
+type alias Letter =
+    { char : Char
+    , match : Match
+    }
+
+
+type Tile
+    = EmptyTile
+    | FilledTile Letter
+
+
+type alias Word =
+    List Tile
+
+
+fromCharList chars =
+    List.map (\char -> { char = char, match = Unmatched }) chars
+
+
+guess1 =
+    fromCharList [ 'F', 'U', 'R', 'B', 'A' ]
+
+
+solution =
+    fromCharList [ 'B', 'U', 'F', 'F', 'A' ]
+
+
+zip a b =
+    List.map2 Tuple.pair a b
+
+
+matchExactTile ( a, b ) =
+    if a.char == b.char then
+        ( { a | match = Exact }, { b | match = Exact } )
+        -- default format with a blank line -> error when pasting in elm repl
+
+    else
+        ( a, b )
+
+
+matchExact ( sol, guess ) =
+    List.unzip (List.map matchExactTile (zip sol guess))


### PR DESCRIPTION
refactor-word: goal is to refactor word to be able to show complete guess, current guess and empty words
- [x] new Word type
- [x] refactor model (add current)
- [x] new test data for init model