### PR TITLE
fix: added unknown match status

### DIFF
--- a/src/Word.elm
+++ b/src/Word.elm
@@ -5,9 +5,10 @@ import Test exposing (Test, describe, test)
 
 
 type MatchedChar
-    = Missing Char --grey
-    | Exact Char --green
-    | Present Char --yellow
+    = Missing Char -- dark grey
+    | Exact Char -- green
+    | Present Char -- yellow
+    | Unknown Char -- light gray
 
 
 toMatched : List Char -> List Char -> List MatchedChar
@@ -113,7 +114,7 @@ rematch guess solution =
                         ( Missing _, newState ) ->
                             Missing g :: matchGuessChars (i + 1) gs newState target
 
-                        ( Present _, newState ) ->
+                        ( _, newState ) ->
                             Present g :: matchGuessChars (i + 1) gs newState target
     in
     matchGuessChars 0 guess equalChars solution


### PR DESCRIPTION
This PR introduces a 4th matching status: `Unknown`.
Characters that are not yet matched in any way have this status: when searching for keyboard colors, the state is assumed to be `Unknown` and when guesses are compared, it is upgraded to `Missing`, `Present` and `Exact` only for characters that are matched.

Fixes issue #18 