### PR TITLE
fix: responsive wrapper [fixes #10]

### DIFF
--- a/.github/workflows/elm-to-gh-pages.yml
+++ b/.github/workflows/elm-to-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
         uses: jorelali/setup-elm@v5
         with:
           elm-version: 0.19.1
-      - run: elm make src/Main.elm
+      - run: elm make src/Main.elm --output=static/main.js
 
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -43,7 +43,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: '.'
+          path: 'static/'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/elm-to-gh-pages.yml
+++ b/.github/workflows/elm-to-gh-pages.yml
@@ -37,17 +37,13 @@ jobs:
           elm-version: 0.19.1
       - run: elm make src/Main.elm --output=static/main.js
 
-      - name: Pack values to upload
-        shell: sh
-        run: tar --directory static -cvf ../artifact.tar .
-
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'artifact.tar'
+          path: 'static'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/elm-to-gh-pages.yml
+++ b/.github/workflows/elm-to-gh-pages.yml
@@ -37,13 +37,17 @@ jobs:
           elm-version: 0.19.1
       - run: elm make src/Main.elm --output=static/main.js
 
+      - name: Pack values to upload
+        shell: sh
+        run: tar --directory static -cvf ../artifact.tar .
+
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'static/'
+          path: 'artifact.tar'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 elm-stuff
 # elm-repl generated files
 repl-temp-*
+# output of elm make
+static/main.js

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that might be inspired to something mentioned in this [article](https://www.404m
 
 goal is to have in production version that can replace this (with changes in the UI, e.g. color changes) https://github.com/pietroppeter/wordle-it
 
-we still have to complete the MVP, these are some 
+we still have to complete the MVP, these are some
 ideas for additional features
 - play a past game
 - history of all your past games
@@ -16,6 +16,14 @@ Shared project by @pietroppeter (beginner in Elm and functional languages) and @
 
 We also tried (on the first meetup) to have a NixOS based Elm setup with help by @kristoff-it but it did not work out.
 In the end it is actually very simple to just setup elm with the installer.
+
+## Building
+
+Then serve the `static` folder
+
+```
+elm make src/Main.elm --output=static/main.js
+```
 
 ## tests
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Parlelm</title>
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <div id="main"></div>
+    <script>
+      var app = Elm.Main.init({ node: document.getElementById("main") });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This tag does the magic and should fix sizing on mobiles:

```
<meta name="viewport" content="width=device-width, initial-scale=1.0" />
```

But `<head>` elements are not managed by Elm, so we can just insert elm's output into an HTML page and build with

```
elm make src/Main.elm --output=static/main.js
```

I'm not too sure about the github pages workflow.